### PR TITLE
Amann/feature/no more hacky time buffer thing

### DIFF
--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import List, Optional
 
 import singer

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Optional
 
 import singer
@@ -24,6 +25,30 @@ def pipeline_is_completed(workflows):
     return not running_workflows
 
 
+def get_size(obj, seen=None):
+    """
+    Recursively finds size of objects
+    https://gist.githubusercontent.com/bosswissam/a369b7a31d9dcab46b4a034be7d263b2/raw/f99d210019c1fac6bb46d2da81dcdf5ef9932172/pysize.py
+    """
+    size = sys.getsizeof(obj)
+    if seen is None:
+        seen = set()
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    # Important mark as seen *before* entering recursion to gracefully handle
+    # self-referential objects
+    seen.add(obj_id)
+    if isinstance(obj, dict):
+        size += sum([get_size(v, seen) for v in obj.values()])
+        size += sum([get_size(k, seen) for k in obj.keys()])
+    elif hasattr(obj, '__dict__'):
+        size += get_size(obj.__dict__, seen)
+    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
+        size += sum([get_size(i, seen) for i in obj])
+    return size
+
+
 def get_all_pipelines_while_bookmark(project, bookmark_time):
     """
     Return all pipelines, in ascending order of updated_at, which are
@@ -35,6 +60,7 @@ def get_all_pipelines_while_bookmark(project, bookmark_time):
     # Pipelines are ordered updated_at desc, so we reverse the list
     pipelines = []
     for pipeline in get_all_items('pipelines', pipeline_url):
+        LOGGER.info(f"pipeline size: {get_size(pipeline)}")
         pipeline_updated_at = singer.utils.strptime_to_utc(
             pipeline.get('updated_at'))
 
@@ -45,6 +71,8 @@ def get_all_pipelines_while_bookmark(project, bookmark_time):
             break
 
         pipelines.append(pipeline)
+
+    LOGGER.info(f"pipelines size: {get_size(pipelines)}, {len(pipelines)}")
 
     return pipelines[::-1]
 

--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -99,7 +99,8 @@ def get_all_pipelines(schemas: dict, project: str, state: dict, metadata: dict, 
     for pipeline in get_all_pipelines_while_bookmark(project, bookmark_time):
         # grab all workflows for this pipeline
         workflow_extraction_time = singer.utils.now()
-        workflows = list(get_all_workflows_for_pipeline(pipeline.get("id")))
+        workflows = get_all_workflows_for_pipeline(pipeline.get("id"))
+        LOGGER.info(f"workflows size: {get_size(workflows)}, {len(workflows)}")
 
         # We terminate extracting once we come across currently running pipelines
         if not pipeline_is_completed(workflows):
@@ -148,10 +149,10 @@ def get_all_workflows_for_pipeline(
     """
     https://circleci.com/docs/api/v2/#operation/listWorkflowsByPipelineId
     """
-    workflow_url = f"https://circleci.com/api/v2/pipeline/{pipeline_id}/workflow"
-
-    for workflow in get_all_items('workflows', workflow_url):
-        yield workflow
+    return list(get_all_items(
+        'workflows',
+        f"https://circleci.com/api/v2/pipeline/{pipeline_id}/workflow"
+    ))
 
 
 def emit_all_workflows_for_pipeline(

--- a/tap_circle_ci/tap_circle_ci.py
+++ b/tap_circle_ci/tap_circle_ci.py
@@ -40,9 +40,8 @@ def discover() -> singer.catalog.Catalog:
 
     for schema_name, schema in raw_schemas.items():
 
-        # TODO: populate any metadata and stream's key properties here..
+        # TODO: populate any metadata here..
         stream_metadata = []
-        stream_key_properties = []
 
         # create and add catalog entry
         catalog_entry = {


### PR DESCRIPTION
# Motivation

The lag buffer is admittedly hacky, and by pre-fetching the `pipelines`, and then pre-fetching the `workflows` we can sidestep that annoying problem.

## Notes

This does increase the memory footprint of this `tap` on the first run as we have to pull _all_ `pipelines` in at the same time. 

For estimating memory footprint of each `pipeline` we can use estimations detailed below. However, simply instrumenting the pipeline code with `sys.getsizeof` we can get some benchmarks. The commit producing these results is included in the history of this pr, and backed out so as to not clutter the `tap` itself:

```
INFO pipeline size: 4017
INFO pipeline size: 3982
INFO pipeline size: 3976
INFO pipeline size: 3996
INFO pipeline size: 3978
INFO pipeline size: 3973
INFO pipeline size: 3992
INFO pipeline size: 3962
INFO pipeline size: 3959
INFO pipeline size: 3971
INFO pipeline size: 3954
INFO pipeline size: 3960
INFO pipeline size: 3951
INFO pipeline size: 3927
INFO pipeline size: 3938
INFO pipeline size: 3833
INFO pipelines size: 44229, 16
...
INFO workflows size: 1584, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
INFO workflows size: 1577, 1
...
NFO workflows size: 1578, 1
...
INFO workflows size: 1578, 1
...
```

Max size of a `pipeline`: 4017
Max size of a `workflow`: 1584

Let's say that unlike this repo, a `pipeline` has a worst case size of 4200 bytes. That would mean being able to fit 238 pipelines into a single megabyte. For a lot of folks, it's not unreasonable to assign half a gig to a running process. Even doing something like lambda, you're reasonably taking 512 MB. That'd be ➡️ 238 * 512 = 121,856 `pipelines` able to fit in memory. With other overheads, let's just make this number 100K.

This is ONLY for the initial sync as well. Every-time after, we should be able to stop after only a few pages because of our bookmark.

Finally, let's say that also unlike this repo, a `pipeline` has on average 5 `workflows`, they're 1600 each (which is really including some overhead for the list, but etc.). That's an additional 8 kilobytes (negligible).

### Sources

- https://rushter.com/blog/python-strings-and-memory/
- https://stackoverflow.com/questions/10264874/python-reducing-memory-usage-of-dictionary

## Suggested Musical Pairing

https://soundcloud.com/deathfromabove1979/one-one
