### PR TITLE
Amann/feature/incremental bookmarks

### DIFF
--- a/tap_circle_ci/streams.py
+++ b/tap_circle_ci/streams.py
@@ -54,9 +54,6 @@ def get_all_pipelines_while_bookmark(project, state):
     all fetchable pipelines.
     """
     bookmark = get_bookmark(state, project)
-    # We immediately write the bookmark _back_ to make state management simpler downstream
-    # ie, if we don't end up parsing _any_ pipelines, we still emit the state we were given
-    state = write_bookmark(state, project, bookmark)
 
     pipeline_url = f'https://circleci.com/api/v2/project/{project}/pipeline'
 


### PR DESCRIPTION
# Motivation

Having to deal with CCI API telling me to back off, or try again later only to have to start from the same place with the bookmark. We can instead, output a bookmark update on every pipeline we sync to eek out incremental progress. Could have thrown a buffer number in here, but decided against it.

## Suggested Musical Pairing

https://soundcloud.com/idles/war